### PR TITLE
Added functionality for J&S, C&L Annuities. 

### DIFF
--- a/Annuity_Factor_Calculator/AFC_class_tests.py
+++ b/Annuity_Factor_Calculator/AFC_class_tests.py
@@ -93,7 +93,7 @@ Test3Inputs = {
     , 'SetbackYearsMale':0 #-10->10
     , 'SetbackYearsFemale':0 #-10->10
 }
-Test3ExpectedResult = 6.4657
+Test3ExpectedResult = 5.0195
 ExecuteTest(3, Test3Inputs, Test3ExpectedResult, mortTablePath)
 
 #Test 4: C&L
@@ -690,10 +690,17 @@ Test25Inputs = {
 Test25ExpectedResult = 4.2953
 ExecuteTest(25, Test25Inputs, Test25ExpectedResult, mortTablePath)
 
+
+
 '''
 
 Note - I would very much like to be able to use an array of discount rates at some point.
 Right now, my expected results are coming from the SOA calculator (https://afc.soa.org/#Calculator).
 That does not currently work with an array of discount rates, so I will need to find a different way of verifying calcs when I move to a discount array.
+
+Note 2 - I don't like the way this workbook is set up
+(1) I think I should return a value instead of printing a value. My feeling is that such a construction would be easier to include into a CICD framework
+(2) I think numbering the tests is weird. I should put them in a named tuple with: Name, Input dict, expected output, maybe a blank field for result??
+(3) Oh, btw, Mort table path maybe should be hardcoded or something. Like a global var. Just a single table.
 
 '''

--- a/Annuity_Factor_Calculator/Annuity_Factor_Calculator.py
+++ b/Annuity_Factor_Calculator/Annuity_Factor_Calculator.py
@@ -1,22 +1,31 @@
 import pandas as pd
 import numpy as np
+import datetime
+
+pd.set_option('display.max_rows', 500)
 
 class Annuity_Factor_Calculator:
 
     def CalcPVF(self, UserInputs_dict:{}, mortTablepath:str):
         pmt_timing = self.GetPaymentTiming(UserInputs_dict['PaymentFrequency'])
-        ptcp_mort_df = self.PrepMortality(mortTablepath
+        mort_df = self.PrepMortality(mortTablepath
                             , UserInputs_dict['MortalityBeforeBCA']
                             , UserInputs_dict['MortalityAfterBCA']
+                            , UserInputs_dict['ProjectionMethod']
                             , UserInputs_dict['PrimaryAnnuitantGender']
                             , UserInputs_dict['PrimaryAnnuitantAge']
+                            , UserInputs_dict['BeneficiaryGender']
+                            , UserInputs_dict['BeneficiaryAge']
                             , UserInputs_dict['BenefitCommencementAge']
                             )
-        calc_df = self.InitializePVFCalc(UserInputs_dict['PrimaryAnnuitantAge'])
-        calc_df = self.calc_nPx(calc_df, ptcp_mort_df[['ptcp_age', 'PriorQx']], UserInputs_dict['PrimaryAnnuitantAge'])
+        calc_df = self.InitializePVFCalc(UserInputs_dict['PrimaryAnnuitantAge'], UserInputs_dict['AnnuityType'], UserInputs_dict['BeneficiaryAge'])
+        calc_df = self.calc_nPx(calc_df, mort_df, UserInputs_dict['PrimaryAnnuitantAge'], mort_type = 'PrimaryAnnuitant')
+        if (UserInputs_dict['AnnuityType']=="J&S") or (UserInputs_dict['AnnuityType']=='JL'):
+                calc_df = self.calc_nPx(calc_df, mort_df, UserInputs_dict['BeneficiaryAge'], mort_type = 'Beneficiary')
+
         calc_df = self.calc_discountFactor(calc_df, UserInputs_dict['DiscountRate'], pmt_timing)
-        calc_df = self.calc_PaymentAmounts(calc_df, UserInputs_dict['BenefitCommencementAge'])
-        pvf = self.calculateDiscountedPV(calc_df)
+        calc_df = self.calc_PaymentAmounts(calc_df, UserInputs_dict['BenefitCommencementAge'], UserInputs_dict['AnnualCOLA'], UserInputs_dict['AnnuityType'], UserInputs_dict['SurvivorBenefitPrct'], UserInputs_dict['CertainPeriod(years)'])
+        pvf = self.calculateDiscountedPV(calc_df, UserInputs_dict['AnnuityType'], UserInputs_dict['BenefitCommencementAge'])
         return pvf
 
     @staticmethod
@@ -39,39 +48,87 @@ class Annuity_Factor_Calculator:
                 return "INVALID INPUT"
 
     @staticmethod
-    def PrepMortality(BaseMortPath, PreCommencementMortality, PostCommencementMortality, PrimaryAnnuitantGender, PrimaryAnnuitantAge, BenefitCommencementAge):
-        
+    def PrepMortality(BaseMortPath, PreCommencementMortality, PostCommencementMortality, ProjectionMethod, PrimaryAnnuitantGender, PrimaryAnnuitantAge, BeneficiaryGender, BeneficiaryAge, BenefitCommencementAge):
+    
+        #TODO this does not do any mort projection. I think I will rename this to "prepRawMortality" and add a function to apply mort projection down the road
+
+        #Get Mortality Tables
         mort_df = pd.read_parquet(BaseMortPath
                             , columns=['MortalityTableName', 'BaseYear', 'Sex', 'Age', 'Qx']
                             , filters = [[('MortalityTableName', '==', PreCommencementMortality)], [('MortalityTableName', '==', PostCommencementMortality)]]) 
 
-        Ptcp_PreRetMort_df = mort_df[(mort_df['MortalityTableName'] == PreCommencementMortality)
+        #determine PA table 
+        PrimaryAnnuitant_PreRetMort_df = mort_df[(mort_df['MortalityTableName'] == PreCommencementMortality)
                             &(mort_df['Sex']==PrimaryAnnuitantGender)
                             &(mort_df['Age']>=PrimaryAnnuitantAge)
                             &(mort_df['Age']<BenefitCommencementAge)]
-        Ptcp_PostRetMort_df = mort_df[(mort_df['MortalityTableName'] == PostCommencementMortality)
+        PrimaryAnnuitant_PostRetMort_df = mort_df[(mort_df['MortalityTableName'] == PostCommencementMortality)
                             &(mort_df['Sex']==PrimaryAnnuitantGender)
                             &(mort_df['Age']>=BenefitCommencementAge)
                             &(mort_df['Age']<=120)] #TODO reconsider hardcode of max age
 
-        ptcp_mort_df = pd.concat([Ptcp_PreRetMort_df, Ptcp_PostRetMort_df]).rename(columns={'Age':'ptcp_age', 'Qx':'PriorQx'}) #renaming Qx in preparation for the offset on next line
-        ptcp_mort_df['ptcp_age'] = ptcp_mort_df['ptcp_age'] + 1 #note 1 year offset so merge gets ages on the same row
+        PrimaryAnnuitant_mort_df = pd.concat([PrimaryAnnuitant_PreRetMort_df, PrimaryAnnuitant_PostRetMort_df]).rename(columns={'Qx':'PriorQx'}) #renaming Qx in preparation for the offset on next line
+        PrimaryAnnuitant_mort_df['Age'] = PrimaryAnnuitant_mort_df['Age'] + 1 #note 1 year offset so merge gets ages on the same row
 
-        return ptcp_mort_df
+        #determine whether Beneficiary table will be the same as PA table if age and gender is the same
+        BeneficiaryTable_Is_PrimaryTable = False
+        if (PrimaryAnnuitantGender == BeneficiaryGender) and (PrimaryAnnuitantAge == BeneficiaryAge):
+            BeneficiaryTable_Is_PrimaryTable = True
+
+        #BenefitCommencementBeneficiaryAge = BenefitCommencementAge - PrimaryAnnuitantAge + BeneficiaryAge 
+        #TODO SOA calculator appears to be flipping beneficiary mortality tables at Primary Annuitant Commencement Age
+        #That's a reasonable asusmption, but I don't necessarily agree with it. I may add my own input for Beneficiary BCA. 
+        #For now, sticking with PA BCA to match SOA
+
+        if BeneficiaryTable_Is_PrimaryTable:
+            Beneficiary_mort_df = PrimaryAnnuitant_mort_df.copy()
+        else:
+            Beneficiary_PreRetMort_df = mort_df[(mort_df['MortalityTableName'] == PreCommencementMortality)
+                                &(mort_df['Sex']==BeneficiaryGender)
+                                &(mort_df['Age']>=BeneficiaryAge)
+                                &(mort_df['Age']<BenefitCommencementAge)]
+
+            Beneficiary_PostRetMort_df = mort_df[(mort_df['MortalityTableName'] == PostCommencementMortality)
+                                &(mort_df['Sex']==BeneficiaryGender)
+                                &(mort_df['Age']>=BenefitCommencementAge)
+                                &(mort_df['Age']<=120)] #TODO reconsider hardcode of max age
+
+            Beneficiary_mort_df = pd.concat([Beneficiary_PreRetMort_df, Beneficiary_PostRetMort_df]).rename(columns={'Qx':'PriorQx'}) #renaming Qx in preparation for the offset on next line
+            Beneficiary_mort_df['Age'] = Beneficiary_mort_df['Age'] + 1 #note 1 year offset so merge gets ages on the same row
+                
+
+        PrimaryAnnuitant_mort_df['MortType'] = 'PrimaryAnnuitant'
+        Beneficiary_mort_df['MortType'] = 'Beneficiary'
+        mort_df = pd.concat([PrimaryAnnuitant_mort_df, Beneficiary_mort_df])
+
+        return mort_df
 
     @staticmethod
-    def InitializePVFCalc(PrimaryAnnuitantAge):
+    def InitializePVFCalc(PrimaryAnnuitantAge, AnnuityType, BeneficiaryAge):
         calc_df = pd.DataFrame({'Time':np.arange(121)}) #TODO can just pass in PA Age, Beneficiary Age, and BCA, and calc the # of year to initialize
-        calc_df['ptcp_age'] = calc_df['Time'] + PrimaryAnnuitantAge
-        calc_df = calc_df[calc_df['ptcp_age']<=120]#TODO reconsider hardcode. Also this will be different for J&S annuity
+        calc_df['PrimaryAnnuitant_Age'] = calc_df['Time'] + PrimaryAnnuitantAge
+        calc_df['MinAge'] = calc_df['PrimaryAnnuitant_Age']
+
+        if (AnnuityType == 'J&S') or (AnnuityType == 'JL'):
+             calc_df['Beneficiary_Age'] = calc_df['Time'] + BeneficiaryAge
+             calc_df['MinAge'] = np.minimum(calc_df['Beneficiary_Age'], calc_df['PrimaryAnnuitant_Age'])
+
+        calc_df = calc_df[(calc_df['MinAge']<=120)]#TODO reconsider hardcode. 
         return calc_df
 
     @staticmethod
-    def calc_nPx(calc_df, mort_df, PrimaryAnnuitantAge):
-        calc_df = calc_df.merge(mort_df, how = 'left', on = ['ptcp_age'])
-        calc_df['PriorPx'] = 1 - calc_df['PriorQx']
-        calc_df['PriorPx'] = calc_df['PriorPx'].where(calc_df['ptcp_age']!=PrimaryAnnuitantAge, 1) #necessarily, prior Px to current age is 1 because the ptcp has survived to their current age
-        calc_df['nPx'] = calc_df['PriorPx'].cumprod()
+    def calc_nPx(calc_df, mort_df, Age, mort_type):
+
+        filtered_mort_df = mort_df[mort_df['MortType']==mort_type][['PriorQx', 'Age']]
+        filtered_mort_df = filtered_mort_df.rename(columns ={'PriorQx':mort_type+'_PriorQx', 'Age':mort_type+'_Age'})
+
+        #print(calc_df[mort_type+'_Age'])
+        #print(filtered_mort_df[mort_type+'_Age'])
+
+        calc_df = calc_df.merge(filtered_mort_df, how = 'left', on = [mort_type+'_Age'])
+        calc_df[mort_type+'_PriorPx'] = 1 - calc_df[mort_type+'_PriorQx']
+        calc_df[mort_type+'_PriorPx'] = calc_df[mort_type+'_PriorPx'].where(calc_df[mort_type+'_Age']!=Age, 1) #necessarily, prior Px to current age is 1 because the ptcp has survived to their current age
+        calc_df[mort_type+'_nPx'] = calc_df[mort_type+'_PriorPx'].cumprod()
 
         return calc_df
 
@@ -83,16 +140,57 @@ class Annuity_Factor_Calculator:
         return calc_df
 
     @staticmethod
-    def calc_PaymentAmounts(calc_df, BenefitCommencementAge):
-        calc_df['payment'] = 0
-        calc_df['payment'] = calc_df['payment'].where(calc_df['ptcp_age']<BenefitCommencementAge, 1)
+    def calc_PaymentAmounts(calc_df, BenefitCommencementAge, COLA_pct, AnnuityType, SurvivorBenefitPct, CertainPeriod):
+        
+        #SLA payment - JL payment is the same
+        calc_df['sla_payment'] = 0
+        calc_df['sla_payment'] = calc_df['sla_payment'].where(calc_df['PrimaryAnnuitant_Age']<BenefitCommencementAge, 1)
+        
+        #J&S payment
+        if AnnuityType == "J&S":
+            calc_df['jointAndSurvivor_payment'] = calc_df['sla_payment']*SurvivorBenefitPct
+        else:
+            calc_df['jointAndSurvivor_payment'] = 0
+
+        #C&L payment
+        if AnnuityType == "C&L":
+            calc_df['certain_payment'] = 0
+            calc_df['certain_payment'] = calc_df['certain_payment'].where((calc_df['PrimaryAnnuitant_Age']<BenefitCommencementAge), 1)
+            calc_df['certain_payment'] = calc_df['certain_payment'].where((calc_df['PrimaryAnnuitant_Age']<BenefitCommencementAge + CertainPeriod), 0)
+            #adjust SLA payment
+            calc_df['sla_payment'] = calc_df['sla_payment'].where(calc_df['PrimaryAnnuitant_Age']>=BenefitCommencementAge + CertainPeriod, 0)
+        else:
+            calc_df['certain_payment'] = 0
+        
+        #apply COLA
+        calc_df['Time_From_BCA'] = np.maximum(0, calc_df['PrimaryAnnuitant_Age'] - BenefitCommencementAge)
+        calc_df['COLA_Factor'] = (1+COLA_pct)**(calc_df['Time_From_BCA'])
+        calc_df['sla_payment'] = calc_df['sla_payment'] * calc_df['COLA_Factor']
+        calc_df['jointAndSurvivor_payment'] = calc_df['jointAndSurvivor_payment'] * calc_df['COLA_Factor']
+        calc_df['certain_payment'] = calc_df['certain_payment'] * calc_df['COLA_Factor']
         
         return calc_df
 
     @staticmethod
-    def calculateDiscountedPV(calc_df):
-        calc_df['discounted_payment'] = calc_df['payment'] * calc_df['discount_factor'] * calc_df['nPx']
+    def calculateDiscountedPV(calc_df, AnnuityType, BenefitCommencementAge):
+        match AnnuityType:
+            case "SLA":
+                 calc_df['discounted_payment'] = calc_df['sla_payment'] * calc_df['discount_factor'] * calc_df['PrimaryAnnuitant_nPx']
+            case "J&S":
+                calc_df['sla_discounted_payment'] = calc_df['sla_payment'] * calc_df['discount_factor'] * calc_df['PrimaryAnnuitant_nPx']
+                calc_df['jointAndSurvivor_discounted_payment'] = calc_df['jointAndSurvivor_payment'] * calc_df['discount_factor'] * calc_df['Beneficiary_nPx']*(1-calc_df['PrimaryAnnuitant_nPx'])
+                calc_df['discounted_payment'] = calc_df['sla_discounted_payment'] + calc_df['jointAndSurvivor_discounted_payment']
+            case "C&L":
+                SurvivalToStart = calc_df[calc_df['PrimaryAnnuitant_Age']==BenefitCommencementAge]['PrimaryAnnuitant_nPx'].values[0]
+                calc_df['sla_discounted_payment'] = calc_df['sla_payment'] * calc_df['discount_factor'] * calc_df['PrimaryAnnuitant_nPx']                
+                calc_df['certain_discounted_payment'] = calc_df['certain_payment'] * calc_df['discount_factor']*SurvivalToStart
+                calc_df['discounted_payment'] = calc_df['sla_discounted_payment'] + calc_df['certain_discounted_payment']
+            case "JL":
+                calc_df['discounted_payment'] = calc_df['sla_payment']* calc_df['discount_factor'] * calc_df['PrimaryAnnuitant_nPx']* calc_df['Beneficiary_nPx']
+
         pvf = calc_df['discounted_payment'].sum().round(4) #TODO Parametrize rounding
+
+        calc_df.to_csv('/home/jroth/Documents/Repos/ActuarialTools/Annuity_Factor_Calculator/testFiles/'+str(datetime.datetime.now())+".csv", index=False)
 
         return pvf
 


### PR DESCRIPTION
Corresponding test cases work now.

I do not completely agree with SOA calculator regarding Beneficiary mortality rates, but do not have a better assumption on hand. Spent a few days sorting that out.

Note addition of code in calculateDiscountedPV which saves the final calc df to a dataframe. This is temporary while I build out all the core functionality of the system.

Need to refactor calculator to have only a single primary calc df which is operated on by all functions. This would be a global variable and I effing hate global variables (Or rather, I strongly prefer functions with return values over functions which modify global data structures). But it just makes more sense here.